### PR TITLE
Update Docker for SDL2

### DIFF
--- a/fteqw-docker/Dockerfile
+++ b/fteqw-docker/Dockerfile
@@ -1,91 +1,31 @@
-# Source Ubuntu for better package sourcing
-FROM ubuntu:18.04
+# Source Debian for better package sourcing when cross-compiling
+FROM debian:bookworm-slim
 
-# Currently broken macOS SDK
-COPY MacOSX10.14.sdk.tar.xz /
+# For obtaining SDL when cross-compiling
+RUN dpkg --add-architecture i386 \
+ && dpkg --add-architecture armhf \
+ && dpkg --add-architecture arm64
 
-# Set up some EMSDK variables
-ARG EMSCRIPTEN_VERSION=tot
-ENV EMSDK /emsdk
-
-WORKDIR /
-
-# For building 32 bit binaries
-RUN dpkg --add-architecture i386
-
-# First round of apt spam
 RUN apt-get update \
  && apt-get install -y \
-    build-essential \
-    cmake \
     zip \
     git \
     wget \
-    gcc-multilib \
-    libasound2-dev \
-    libbz2-dev \
-    libegl1-mesa-dev \
-    libbullet-dev \
-    libfreetype6-dev \
-    libgnutls28-dev \
-    libjpeg-dev \
-    libpng-dev \
-    libvorbis-dev \
-    libvulkan-dev \
-    libwayland-dev \
-    libxcursor-dev \
-    libxkbcommon-dev \
-    libxrandr-dev \
-    libavdevice-dev \
-    libxml2-dev \
-    libssl-dev \
-    libz-dev \
-    clang \
-    llvm \
-    mingw-w64 \
-    mingw-w64-common \
+    emscripten \
+    build-essential \
+    crossbuild-essential-i386 \
+    crossbuild-essential-armhf \
+    crossbuild-essential-arm64 \
+    gcc-mingw-w64-i686 \
+    gcc-mingw-w64-x86-64 \
     mingw-w64-i686-dev \
     mingw-w64-x86-64-dev \
     mingw-w64-tools \
-    linux-libc-dev:i386
-
-# EMSDK apt spam (2nd round)
-RUN apt-get install -y \
-    binutils \
-    ca-certificates \
-    file \
-    python3 \
-    python3-pip
-
-# Third wave + delete apt list to save space
-RUN apt-get install -y \
-    gcc-arm-linux-gnueabihf \
-    gcc-aarch64-linux-gnu \
-    binutils-aarch64-linux-gnu \
- && rm -rf /var/lib/apt/lists/*
-
-# Proceed with EMSDK install
-RUN cd / && \
-    git clone https://github.com/emscripten-core/emsdk && \
-    cd ${EMSDK} && \
-    ./emsdk install ${EMSCRIPTEN_VERSION}
-
-# Set up OSXCross with the macOS SDK
-RUN cd /opt \
- && git clone https://github.com/tpoechtrager/osxcross.git \
- && cd osxcross \
- && git checkout 16efae89925c5cee1a7ae946c036c570f688f852 \
- && mv /MacOSX10.14.sdk.tar.xz tarballs \
- && PORTABLE=1 UNATTENDED=1 ./build.sh
-
-# OSXCross path
-ENV PATH $PATH:/opt/osxcross/target/bin
-
-# Edit path again, but for EMSDK
-ENV EMSDK=/emsdk \
-    EM_CONFIG=/emsdk/.emscripten \
-    EMSDK_NODE=/emsdk/node/14.18.2_64bit/bin/node \
-    PATH="/emsdk:/emsdk/upstream/emscripten:/emsdk/upstream/bin:/emsdk/node/14.18.2_64bit/bin:${PATH}"
-
-# (Finally) create a config for emcc
-RUN emcc --generate-config
+    libsdl2-dev \
+    libsdl2-dev:i386 \
+    libsdl2-dev:arm64 \
+    libsdl2-dev:armhf \
+    libgnutls28-dev \
+    libgnutls28-dev:i386 \
+    libgnutls28-dev:arm64 \
+    libgnutls28-dev:armhf


### PR DESCRIPTION
There are various changes put into this one commit, I am too lazy to split them up. I have tested this passes CI for all desktop platforms + web.

I switched from Ubuntu to Debian, because dpkg --add-architecture doesn't seem to work on Ubuntu, and it's necessary to obtain SDL so cross-compilation works.

I removed osxcross because it builds llvm, which takes a long time, and I didn't want to wait. It's broken/unused anyway, so not really a loss. It can still be added back more carefully in future.

I fixed the web CI by installing Debian's emscripten package. It seems to build fine, I downloaded the artifact and tested it locally with emrun, and the fte help menu showed up. I'm not sure how to test further than that, but I doubt anything is broken.